### PR TITLE
Path conflict within linux scripts

### DIFF
--- a/Makefile-Linux.mk
+++ b/Makefile-Linux.mk
@@ -33,7 +33,7 @@ MONITOR_BAUDRATE  = 115200
 
 ### AVR_TOOLS_DIR
 ### Path to the AVR tools directory such as avr-gcc, avr-g++, etc.
-AVR_TOOLS_DIR     = /usr/bin
+AVR_TOOLS_DIR     = /usr
 
 ### AVRDDUDE
 ### Path to avrdude directory.


### PR DESCRIPTION
Hi guys,

Firstly, thank you for your work.

I found an issue with a variable defined in  Makefile-Linux.mk. The variable AVR_TOOLS_DIR should not be manually appended by a "/bin".

hope this help !
