### PR TITLE
Fixed OS X brew tap git hub rebo

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,7 +68,7 @@ $ sudo apt-get install git arduino
 We've made a [Homebrew](http://brew.sh/) `formula` that you can `tap` like [*dat ass*](https://www.youtube.com/watch?v=18gp_NBg43c):
 
 ```Bash
-$ brew tap WeAreLeka/avr
+$ brew tap WeAreLeka/homebrew-avr
 $ brew install avr-libc
 $ brew install avrdude
 ```


### PR DESCRIPTION
Was getting error: 
fatal: repository 'https://github.com/WeAreLeka/homebrew-var/' not found

Changed from "avr"
to "homebrew-avr"
so it matches https://github.com/WeAreLeka/homebrew-avr
