### PR TITLE
fix: use branch auto-lib for Arduino-Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Arduino-Makefile"]
 	path = Arduino-Makefile
-	url = https://github.com/WeAreLeka/Arduino-Makefile
+	url = https://github.com/leka/Arduino-Makefile.git


### PR DESCRIPTION
Hello,
The Arduino-Makefile submodule configuration points to #8c8ebf71a0b7 which is on no branches and is thus not retrieved when doing the `git submodule update`. From what I see, it is strictly equivalent to the top of branch `auto-lib`.
I also changed `.gitmodules' to point to the new repository.
M.